### PR TITLE
fix: Retorna nas ofertas apenas produtos com estoque positivo

### DIFF
--- a/src/modules/produtos/actions.js
+++ b/src/modules/produtos/actions.js
@@ -1,4 +1,5 @@
 import { Produto } from "../../models/index";
+import { Op } from "sequelize";
 import fs from "fs";
 
 const index = async (req, res) => {
@@ -39,6 +40,11 @@ const offers = async (req, res) => {
   // #swagger.summary = 'Retorna uma lista com os três produtos mais baratos.'
   try {
     const produtos = await Produto.findAll({
+      where: {
+        estoque: {
+          [Op.gt]: 0,
+        },
+      },
       order: [["preco", "DESC"]],
       limit: 4,
     });


### PR DESCRIPTION
# Descrição

A rota de ofertas estava retornando produtos com estoque 0 ou negativo e o front permitindo que esses produtos fossem add ao carrinho, mesmo sem estoque. Para resolver, add uma condição à query para carregar apenas produtos com estoque positivo.